### PR TITLE
Refractor order model

### DIFF
--- a/app/parcel_order/views.py
+++ b/app/parcel_order/views.py
@@ -82,18 +82,14 @@ class SingleOrder(flask.views.MethodView):
         """
              This method updates the action of an order.
         """
-        data = request.get_json()
-        action = data.get('user_action')
-        if validate_data(action):
-            return make_response(jsonify({'message': 'Please add the action you want to carry out'}), 400)
 
-        if action == "cancel":
-            for count, order in enumerate(orders_db):
-                if order.get("parcel_order_id") == parcel_id:
-                    order["action"] = "Cancelled"
-                    return make_response(jsonify({"message": "order has been canceled succesfully"}), 200)
-            return make_response(jsonify({"message": "Failled to cancel the order"}), 400)
-        return make_response(jsonify({"message": "Incorrect action specified"}), 400)
+
+        for count, order in enumerate(orders_db):
+            if order.get("parcel_order_id") == parcel_id:
+                order["status"] = "Cancelled"
+                return make_response(jsonify({"message": "order has been canceled succesfully"}), 200)
+        return make_response(jsonify({"message": "Failled to cancel the order"}), 400)
+
 
 
 class UserOrder(flask.views.MethodView):

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -9,7 +9,7 @@ class UserRegistration(flask.views.MethodView):
 
     def get(self):
         """
-             This method returns all orders created
+             This method returns all users created
         """
         if not users_data:
             return make_response(jsonify({"message": "No Registered users"}), 200)

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -177,46 +177,10 @@ class BaseCase(unittest.TestCase):
                            headers={'Authorization': self.get_token()}
                            )
 
-        response2 = self.client().put("/api/v1/parcels/1/cancel", content_type='application/json', \
-                                      data=json.dumps(user_action_data))
+        response2 = self.client().put("/api/v1/parcels/1/cancel", content_type='application/json')
         self.assertEqual(response2.status_code, 200)
 
-    def test_change_parcel_action_to_cancelled_invalid_action(self):
-        '''Test to cancel an order invalid action status'''
-        self.client().post('/api/v1/signup',
-                           content_type='application/json', data=json.dumps(user_register_data)
-                           )
-        self.client().post('/api/v1/login',
-                           content_type='application/json', data=json.dumps(user_login_data)
-                           )
-        self.client().post('/api/v1/parcels',
-                           content_type='application/json', data=json.dumps(post_an_order),
-                           headers={'Authorization': self.get_token()}
-                           )
 
-        response = self.client().put("/api/v1/parcels/1/cancel", content_type='application/json', \
-                                     data=json.dumps(user_action_data_invalid_action))
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Incorrect action specified', str(response.data))
-
-    def test_change_parcel_action_to_cancelled_no_action(self):
-        '''Test to cancel an order invalid action status'''
-        self.client().post('/api/v1/signup',
-                           content_type='application/json', data=json.dumps(user_register_data)
-                           )
-        self.client().post('/api/v1/login',
-                           content_type='application/json', data=json.dumps(user_login_data)
-                           )
-        self.client().post('/api/v1/parcels',
-                           content_type='application/json', data=json.dumps(post_an_order),
-                           headers={'Authorization': self.get_token()}
-                           )
-        # self.assertEqual(response3.status_code, 201)
-
-        response = self.client().put("/api/v1/parcels/1/cancel", content_type='application/json', \
-                                     data=json.dumps(user_action_data_no_action))
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Please add the action you want to carry out', str(response.data))
 
     def test_change_parcel_action_to_invalid_parcel_id(self):
         '''Test to cancel an order invalid parcel id status'''


### PR DESCRIPTION
**What does this PR do**
These PR refractors the cancel order endpoint and adds validation to user signup preventing you from signing up multiple times

**Tasks completed**
- remove input field on cancel order input
- Add validation to user signup route